### PR TITLE
Pin gem versions in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,15 @@
 source "http://rubygems.org"
 
-gem 'jekyll'
-gem 'redcarpet'
+gem 'jekyll', '3.8.3'
+gem 'redcarpet', '3.4.0'
 
 # jekyll plugins
-gem 'jekyll-feed'
-gem 'jekyll-gist'
-gem 'jekyll-paginate'
-gem 'jekyll-sitemap'
-gem 'jekyll-seo-tag'
-gem 'jekyll-redirect-from'
+gem 'jekyll-feed', '0.10.0'
+gem 'jekyll-gist', '1.5.0'
+gem 'jekyll-paginate', '1.1.0'
+gem 'jekyll-sitemap', '1.2.0'
+gem 'jekyll-seo-tag', '2.5.0'
+gem 'jekyll-redirect-from', '0.9.0'
 
-gem 'jekyll-compose', group: [:jekyll_plugins]
-gem 'github-pages', group: [:jekyll_plugins]
+gem 'jekyll-compose', '0.8.0', group: [:jekyll_plugins]
+gem 'github-pages', '188', group: [:jekyll_plugins]


### PR DESCRIPTION
# What I Did

This PR pins gem versions in `Gemfile`.

# Why

This has multiple benefits:

1. Leads to reproducible builds
1. Ease the work of services like [Dependabot](https://dependabot.com/)