### PR TITLE
Build images on compose up

### DIFF
--- a/fire-up-dev-env.sh
+++ b/fire-up-dev-env.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker-compose -f docker-compose-serve-dev.yaml up
+docker-compose -f docker-compose-serve-dev.yaml up --build

--- a/fresh-start.sh
+++ b/fresh-start.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker-compose -f docker-compose-full-rebuild.yaml up
+docker-compose -f docker-compose-full-rebuild.yaml up --build

--- a/go-productive.sh
+++ b/go-productive.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker-compose -f docker-compose-serve-prod.yaml up
+docker-compose -f docker-compose-serve-prod.yaml up --build


### PR DESCRIPTION
# What I Did

This PR ensures that docker images are built before spinning containers up. It does not add any overhead in case the images are already there because of Docker layer caching.

See [docker-compose up docs](https://docs.docker.com/compose/reference/up/)