### PR TITLE
Dockerfile optimization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,91 +1,23 @@
-FROM ruby:alpine3.7
+FROM ferrarimarco/open-development-environment-jekyll:1.2.0
 
 LABEL maintainer="dcassioli@gmail.com"
 
-RUN apk add --no-cache \
+RUN apk add --no-cache --update \
   autoconf \
   automake \
   build-base \
-  curl \
-  git \
-  gnupg \
-  linux-headers \
-  nasm \
-  python \
-  paxctl
-
-# gpg keys listed at https://github.com/nodejs/node#release-team
-RUN set -ex \
-  && for key in \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    56730D5401028683275BD23C23EFEFE93C4CFFFE \
-    77984A986EBC2AA786BC0F66B01FBB92821C587A \
-  ; do \
-    ( gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
-      || gpg --keyserver pgp.mit.edu --recv-keys "$key" \
-      || gpg --keyserver keyserver.pgp.com --recv-keys "$key" ) \
-  done
-
-ENV NODE_VERSION=v8.11.2
-
-# Download and build Node.js
-RUN curl -o node-${NODE_VERSION}.tar.gz -sSL https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}.tar.gz \
-  && curl -o SHASUMS256.txt.asc -sSL https://nodejs.org/dist/${NODE_VERSION}/SHASUMS256.txt.asc \
-  && gpg --verify SHASUMS256.txt.asc \
-  && grep node-${NODE_VERSION}.tar.gz SHASUMS256.txt.asc | sha256sum -c - \
-  && tar -zxf node-${NODE_VERSION}.tar.gz \
-  && cd node-${NODE_VERSION} \
-  && export GYP_DEFINES="linux_use_gold_flags=0" \
-  && ./configure --prefix=/usr ${CONFIG_FLAGS} \
-  && NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) \
-  && make -j${NPROC} -C out mksnapshot BUILDTYPE=Release \
-  && paxctl -cm out/Release/mksnapshot \
-  && make -j${NPROC} \
-  && make install \
-  && paxctl -cm /usr/bin/node
-
-# Install npm
-RUN cd / \
-  && npm install -g npm@latest \
-  && find /usr/lib/node_modules/npm -name test -o -name .bin -type d | xargs rm -rf;
-
-# Cleanup Node.js build
-RUN rm -rf \
-  /node-${NODE_VERSION}.tar.gz \
-  /SHASUMS256.txt.asc \
-  /node-${NODE_VERSION} \
-  /root/.npm \
-  /root/.node-gyp
-
-RUN gem install bundler
-
-EXPOSE 3000 3001
-
-RUN apk add --update --no-cache \
   ca-certificates \
+  git \
+  nasm \
   openssh-client \
   wget \
-  && update-ca-certificates
+    && update-ca-certificates \
+    && echo -e 'Host *\nUseRoaming no' >> /etc/ssh/ssh_config \
+    && ssh-keyscan github.com >> /etc/ssh/ssh_known_hosts \
+    && wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 \
+    && chmod +x /usr/local/bin/dumb-init \
+    && apk del wget
 
-# Security fix for CVE-2016-0777 and CVE-2016-0778
-RUN echo -e 'Host *\nUseRoaming no' >> /etc/ssh/ssh_config \
-  && mkdir ~/.ssh
-
-# Initialize GitHub host key
-RUN ssh-keyscan github.com >> /etc/ssh/ssh_known_hosts
-
-RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 \
-  && chmod +x /usr/local/bin/dumb-init
-
-RUN apk del \
-    ca-certificates \
-    wget \
-  && rm -rf /var/cache/apk/*
 
 # Force the use of https: instead of git:
 RUN git config --global url."https://".insteadOf git://
@@ -95,12 +27,11 @@ RUN npm install -g gulp-cli
 WORKDIR /usr/app
 
 COPY package.json package.json
-COPY Gemfile Gemfile
-
 RUN npm install \
-  && bundle install \
-  && npm cache clean --force \
-  && rm -f package.json Gemfile Gemfile.lock
+  && npm cache clean --force
+
+COPY Gemfile Gemfile
+RUN bundle install
 
 RUN mkdir -p /root/.ssh
 COPY id_rsa_cassio_pk_1 /root/.ssh/id_rsa
@@ -111,3 +42,5 @@ RUN \
   && git config --global user.name "Davide Cassioli"
 
 ENTRYPOINT [ "dumb-init", "gulp" ]
+
+EXPOSE 3000 3001

--- a/fire-up-dev-env.sh
+++ b/fire-up-dev-env.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker-compose -f docker-compose-serve-dev.yaml up
+docker-compose -f docker-compose-serve-dev.yaml up --build

--- a/fresh-start.sh
+++ b/fresh-start.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker-compose -f docker-compose-full-rebuild.yaml up
+docker-compose -f docker-compose-full-rebuild.yaml up --build

--- a/go-productive.sh
+++ b/go-productive.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker-compose -f docker-compose-serve-prod.yaml up
+docker-compose -f docker-compose-serve-prod.yaml up --build


### PR DESCRIPTION
# What I Did

This PR does the following:

1. Start from `ferrarimarco/open-development-environment-jekyll` so we don't have to build node.js from source (it's already in the image). Also it's an Alpine-based image so smaller footprint
1. Remove packages that were only used to build node.js
1. Install ca-certificates
1. Remove node.js build steps (it's already in the image)
1. Remove npm installation step (it's already in the image)
1. Initial setup (system package installation and cleanup) is now a single step to make better use of Docker layer caching
1. Update APK index before installing packages
1. `bundle install` and `npm install` are now two separate steps that run only when needed (`Gemfile` or `package.json` are modified)

# Why

1. Quicker builds
1. Leaner Docker image